### PR TITLE
update ZH stats to 2M events, lower lr

### DIFF
--- a/enreg/config/benchmarking.yaml
+++ b/enreg/config/benchmarking.yaml
@@ -5,7 +5,7 @@ load_from_json: False
 #this path contains the input ntuples to the ML model (jet & tau properties)
 #the model predictions are stored in separte files
 #and are configured in metrics/regression.yaml -> algorithms/ntuples_dir
-base_ntuple_path: /scratch/persistent/joosep/ml-tau/20240402_full_stats_merged
+base_ntuple_path: /scratch/persistent/joosep/ml-tau/20240520_qq_zh_2m_merged
 comparison_samples:
   - zh_test
   - z_test

--- a/enreg/config/metrics/regression.yaml
+++ b/enreg/config/metrics/regression.yaml
@@ -10,7 +10,7 @@ regression:
       Tight: 0.975
   algorithms:
     ParticleTransformer:
-      ntuples_dir: /local/joosep/ml-tau-en-reg/results/240517_fullstats/jet_regression/ParticleTransformer/
+      ntuples_dir: /local/joosep/ml-tau-en-reg/results/240524_cosinescheduler/jet_regression/ParticleTransformer/
       json_metrics_path: plotting_data.json
       load_from_json: False
       compare: True
@@ -18,7 +18,7 @@ regression:
       hatch: "//"
       color: "tab:purple"
     LorentzNet:
-      ntuples_dir: /local/joosep/ml-tau-en-reg/results/240517_fullstats/jet_regression/LorentzNet/
+      ntuples_dir: /local/joosep/ml-tau-en-reg/results/240524_cosinescheduler/jet_regression/LorentzNet/
       json_metrics_path: plotting_data.json
       load_from_json: False
       compare: True
@@ -26,7 +26,7 @@ regression:
       hatch: "//"
       color: "tab:green"
     SimpleDNN:
-      ntuples_dir: /local/joosep/ml-tau-en-reg/results/240517_fullstats/jet_regression/SimpleDNN/
+      ntuples_dir: /local/joosep/ml-tau-en-reg/results/240524_cosinescheduler/jet_regression/SimpleDNN/
       json_metrics_path: plotting_data.json
       load_from_json: False
       compare: True

--- a/enreg/config/model_training.yaml
+++ b/enreg/config/model_training.yaml
@@ -6,8 +6,8 @@ test: True
 
 #everything that the user should modify is here
 #override these using command line args
-output_dir: training-outputs/240515_fullstats/
-data_path: /scratch/persistent/joosep/ml-tau/20240402_full_stats_merged
+output_dir: training-outputs/240520_qq_zh_2m_merged/
+data_path: /scratch/persistent/joosep/ml-tau/20240520_qq_zh_2m_merged
 
 #override this using command line args
 training_type: dm_multiclass

--- a/enreg/config/model_training.yaml
+++ b/enreg/config/model_training.yaml
@@ -6,7 +6,7 @@ test: True
 
 #everything that the user should modify is here
 #override these using command line args
-output_dir: training-outputs/240520_qq_zh_2m_merged/
+output_dir: training-outputs/240522_qq_zh_2m_merged/
 data_path: /scratch/persistent/joosep/ml-tau/20240520_qq_zh_2m_merged
 
 #override this using command line args

--- a/enreg/config/model_training.yaml
+++ b/enreg/config/model_training.yaml
@@ -6,7 +6,7 @@ test: True
 
 #everything that the user should modify is here
 #override these using command line args
-output_dir: training-outputs/240522_qq_zh_2m_merged/
+output_dir: training-outputs/240524_cosinescheduler/
 data_path: /scratch/persistent/joosep/ml-tau/20240520_qq_zh_2m_merged
 
 #override this using command line args
@@ -36,7 +36,7 @@ fraction_train: 0.8
 fraction_valid: 0.2
 
 dataset:
-  max_cands: 25
+  max_cands: 16
   use_lifetime: False
   min_jet_theta: 0.0
   max_jet_theta: 1000
@@ -55,8 +55,9 @@ num_classes:
   binary_classification: 2
 
 training:
-  num_epochs: 200
-  batch_size: 512
+  lr: 1e-4
+  num_epochs: 100
+  batch_size: 1024
   num_dataloader_workers: 2
   classweight_sig: 1
   classweight_bgr: 10

--- a/enreg/scripts/submit-pytorch-gpu-all.sh
+++ b/enreg/scripts/submit-pytorch-gpu-all.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #edit this as needed
-export OUTDIR=training-outputs/240517_fullstats/
+export OUTDIR=training-outputs/240520_qq_zh_2m_merged/
 
 #for regression and decay mode, use only signal (tau) jets
 export TRAIN_SAMPS=zh_train.parquet

--- a/enreg/scripts/submit-pytorch-gpu-all.sh
+++ b/enreg/scripts/submit-pytorch-gpu-all.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 #edit this as needed
-export OUTDIR=training-outputs/240520_qq_zh_2m_merged/
+export OUTDIR=training-outputs/240522_qq_zh_2m_merged/
+#export OUTDIR=tests
 
 #for regression and decay mode, use only signal (tau) jets
 export TRAIN_SAMPS=zh_train.parquet
@@ -9,7 +10,7 @@ export TEST_SAMPS=z_test.parquet,zh_test.parquet
 sbatch enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=jet_regression model_type=LorentzNet
 sbatch enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=jet_regression model_type=ParticleTransformer
 sbatch enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=jet_regression model_type=SimpleDNN
-
+ 
 sbatch enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=dm_multiclass model_type=LorentzNet
 sbatch enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=dm_multiclass model_type=ParticleTransformer
 sbatch enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=dm_multiclass model_type=SimpleDNN

--- a/enreg/scripts/submit-pytorch-gpu-all.sh
+++ b/enreg/scripts/submit-pytorch-gpu-all.sh
@@ -16,8 +16,8 @@ sbatch enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$
 sbatch enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=dm_multiclass model_type=SimpleDNN
 
 ##for binary classification, use signal (tau) and background (non-tau) jets
-# export TRAIN_SAMPS=zh_train.parquet,qq_train.parquet
-# export TEST_SAMPS=z_test.parquet,zh_test.parquet,qq_test.parquet
-# sbatch enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=binary_classification model_type=LorentzNet
-# sbatch enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=binary_classification model_type=ParticleTransformer
-# sbatch enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=binary_classification model_type=SimpleDNN
+export TRAIN_SAMPS=zh_train.parquet,qq_train.parquet
+export TEST_SAMPS=z_test.parquet,zh_test.parquet,qq_test.parquet
+sbatch --mem-per-gpu 100G enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=binary_classification model_type=LorentzNet
+sbatch --mem-per-gpu 100G enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=binary_classification model_type=ParticleTransformer
+sbatch --mem-per-gpu 100G enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=binary_classification model_type=SimpleDNN

--- a/enreg/scripts/submit-pytorch-gpu-all.sh
+++ b/enreg/scripts/submit-pytorch-gpu-all.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #edit this as needed
-export OUTDIR=training-outputs/240522_qq_zh_2m_merged/
+export OUTDIR=training-outputs/240524_cosinescheduler/
 #export OUTDIR=tests
 
 #for regression and decay mode, use only signal (tau) jets
@@ -16,8 +16,8 @@ sbatch enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$
 sbatch enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=dm_multiclass model_type=SimpleDNN
 
 ##for binary classification, use signal (tau) and background (non-tau) jets
-export TRAIN_SAMPS=zh_train.parquet,qq_train.parquet
-export TEST_SAMPS=z_test.parquet,zh_test.parquet,qq_test.parquet
-sbatch enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=binary_classification model_type=LorentzNet
-sbatch enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=binary_classification model_type=ParticleTransformer
-sbatch enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=binary_classification model_type=SimpleDNN
+# export TRAIN_SAMPS=zh_train.parquet,qq_train.parquet
+# export TEST_SAMPS=z_test.parquet,zh_test.parquet,qq_test.parquet
+# sbatch enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=binary_classification model_type=LorentzNet
+# sbatch enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=binary_classification model_type=ParticleTransformer
+# sbatch enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=binary_classification model_type=SimpleDNN

--- a/enreg/scripts/submit-pytorch-gpu-all.sh
+++ b/enreg/scripts/submit-pytorch-gpu-all.sh
@@ -16,8 +16,8 @@ sbatch enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$
 sbatch enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=dm_multiclass model_type=SimpleDNN
 
 ##for binary classification, use signal (tau) and background (non-tau) jets
-export TRAIN_SAMPS=zh_train.parquet,qq_train.parquet
-export TEST_SAMPS=z_test.parquet,zh_test.parquet,qq_test.parquet
-sbatch --mem-per-gpu 100G enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=binary_classification model_type=LorentzNet
-sbatch --mem-per-gpu 100G enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=binary_classification model_type=ParticleTransformer
-sbatch --mem-per-gpu 100G enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=binary_classification model_type=SimpleDNN
+# export TRAIN_SAMPS=zh_train.parquet,qq_train.parquet
+# export TEST_SAMPS=z_test.parquet,zh_test.parquet,qq_test.parquet
+# sbatch --mem-per-gpu 150G enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=binary_classification model_type=LorentzNet
+# sbatch --mem-per-gpu 150G enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=binary_classification model_type=ParticleTransformer
+# sbatch --mem-per-gpu 150G enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=binary_classification model_type=SimpleDNN

--- a/enreg/scripts/train-pytorch-gpu.sh
+++ b/enreg/scripts/train-pytorch-gpu.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 #SBATCH -p gpu
-#SBATCH --gres gpu:rtx:1
-#SBATCH --mem-per-gpu=20G
+#SBATCH --gres gpu:mig:1
+#SBATCH --mem 40G
 #SBATCH -o logs/slurm-%x-%j-%N.out
 
+env | grep CUDA
+nvidia-smi -L
 ./run.sh python3 enreg/scripts/trainModel.py "$@"

--- a/enreg/scripts/train-pytorch-gpu.sh
+++ b/enreg/scripts/train-pytorch-gpu.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #SBATCH -p gpu
 #SBATCH --gres gpu:mig:1
-#SBATCH --mem 40G
+#SBATCH --mem-per-gpu 40G
 #SBATCH -o logs/slurm-%x-%j-%N.out
 
 env | grep CUDA

--- a/notebooks/DM_CM.ipynb
+++ b/notebooks/DM_CM.ipynb
@@ -35,8 +35,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data_zh = g.load_all_data([\"/scratch/persistent/joosep/ml-tau/20240402_full_stats_merged/zh_test.parquet\"])\n",
-    "data_z = g.load_all_data([\"/scratch/persistent/joosep/ml-tau/20240402_full_stats_merged/z_test.parquet\"])\n"
+    "data_zh = g.load_all_data([\"/scratch/persistent/joosep/ml-tau/20240520_qq_zh_2m_merged/zh_test.parquet\"])\n",
+    "data_z = g.load_all_data([\"/scratch/persistent/joosep/ml-tau/20240520_qq_zh_2m_merged/z_test.parquet\"])\n"
    ]
   },
   {
@@ -47,9 +47,9 @@
    "outputs": [],
    "source": [
     "paths_zh_model = {\n",
-    "    \"ParticleTransformer\": \"/local/joosep/ml-tau-en-reg/results/240517_fullstats/dm_multiclass/ParticleTransformer/zh_test.parquet\",\n",
-    "    \"LorentzNet\": \"/local/joosep/ml-tau-en-reg/results/240517_fullstats/dm_multiclass/LorentzNet/zh_test.parquet\",\n",
-    "    \"SimpleDNN\": \"/local/joosep/ml-tau-en-reg/results/240517_fullstats/dm_multiclass/SimpleDNN/zh_test.parquet\",\n",
+    "    \"ParticleTransformer\": \"/local/joosep/ml-tau-en-reg/results/240524_cosinescheduler/dm_multiclass/ParticleTransformer/zh_test.parquet\",\n",
+    "    \"LorentzNet\": \"/local/joosep/ml-tau-en-reg/results/240524_cosinescheduler/dm_multiclass/LorentzNet/zh_test.parquet\",\n",
+    "    \"SimpleDNN\": \"/local/joosep/ml-tau-en-reg/results/240524_cosinescheduler/dm_multiclass/SimpleDNN/zh_test.parquet\",\n",
     "}\n",
     "\n",
     "data_zh_model = {k: g.load_all_data([v])[\"dm_multiclass\"][\"pred\"] for (k, v) in paths_zh_model.items()}"
@@ -63,9 +63,9 @@
    "outputs": [],
    "source": [
     "paths_z_model = {\n",
-    "    \"ParticleTransformer\": \"/local/joosep/ml-tau-en-reg/results/240517_fullstats/dm_multiclass/ParticleTransformer/z_test.parquet\",\n",
-    "    \"LorentzNet\": \"/local/joosep/ml-tau-en-reg/results/240517_fullstats/dm_multiclass/LorentzNet/z_test.parquet\",\n",
-    "    \"SimpleDNN\": \"/local/joosep/ml-tau-en-reg/results/240517_fullstats/dm_multiclass/SimpleDNN/z_test.parquet\",\n",
+    "    \"ParticleTransformer\": \"/local/joosep/ml-tau-en-reg/results/240524_cosinescheduler/dm_multiclass/ParticleTransformer/z_test.parquet\",\n",
+    "    \"LorentzNet\": \"/local/joosep/ml-tau-en-reg/results/240524_cosinescheduler/dm_multiclass/LorentzNet/z_test.parquet\",\n",
+    "    \"SimpleDNN\": \"/local/joosep/ml-tau-en-reg/results/240524_cosinescheduler/dm_multiclass/SimpleDNN/z_test.parquet\",\n",
     "}\n",
     "\n",
     "data_z_model = {k: g.load_all_data([v])[\"dm_multiclass\"][\"pred\"] for (k, v) in paths_z_model.items()}"
@@ -163,7 +163,7 @@
     "    plt.xlabel('Predicted')\n",
     "    plt.title(title)\n",
     "    plt.savefig(output_path)\n",
-    "    plt.close(\"all\")\n",
+    "    # plt.close(\"all\")\n",
     "    plt.show(block=False)"
    ]
   },

--- a/notebooks/losses.ipynb
+++ b/notebooks/losses.ipynb
@@ -7,11 +7,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from tensorflow.python.summary.summary_iterator import summary_iterator\n",
     "import glob\n",
     "import pandas\n",
     "import matplotlib.pyplot as plt\n",
-    "import seaborn"
+    "import seaborn\n",
+    "import json"
    ]
   },
   {
@@ -27,65 +27,22 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c0ab9978-b4cb-4842-ad21-4ee4493812d0",
+   "id": "c02e1198-6332-42da-b889-b30de72c32b7",
    "metadata": {},
    "outputs": [],
    "source": [
-    "def extract_tb_tag(tb_path, tag=\"Loss/valid\"):\n",
-    "    data = summary_iterator(tb_path)\n",
+    "losses = {}\n",
+    "losses[\"jet_regression\"] = {\n",
+    "    \"LorentzNet\": json.load(open(\"/local/joosep/ml-tau-en-reg/results/240524_cosinescheduler/jet_regression/LorentzNet/history.json\")),\n",
+    "    \"SimpleDNN\": json.load(open(\"/local/joosep/ml-tau-en-reg/results/240524_cosinescheduler/jet_regression/SimpleDNN/history.json\")),\n",
+    "    \"ParticleTransformer\": json.load(open(\"/local/joosep/ml-tau-en-reg/results/240524_cosinescheduler/jet_regression/ParticleTransformer/history.json\")),\n",
+    "}\n",
     "\n",
-    "    df = pandas.DataFrame()\n",
-    "    vals = []\n",
-    "    for e in data:\n",
-    "        for v in e.summary.value:\n",
-    "            if v.tag == tag:\n",
-    "                vals.append(v.simple_value)\n",
-    "    df[tag] = vals\n",
-    "    return df"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "caa35de3-6fe4-40cd-97d0-c2b01efac37f",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "tb_logs = glob.glob(\"/local/joosep/ml-tau-en-reg/results/240517_fullstats/**/events.out.tfevents.*\", recursive=True)\n",
-    "tb_logs"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c29cdf7c-f00d-4e89-8add-c98773693abb",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#get the training and model types \n",
-    "tb_logs_names = [tuple(name.split(\"/\")[-4:-2]) for name in tb_logs]\n",
-    "tb_logs_names"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f2eb7c2d-99fa-4ecc-aeda-3303c423fa6d",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "tb_logs_dict = {k: v for (k, v) in zip(tb_logs_names, tb_logs)}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e14506f8-d0b2-43f7-bc64-deb7cf67ca99",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "loss_train = {k: extract_tb_tag(path, \"Loss/train\") for k, path in tb_logs_dict.items()} \n",
-    "loss_valid = {k: extract_tb_tag(path, \"Loss/valid\") for k, path in tb_logs_dict.items()} "
+    "losses[\"dm_multiclass\"] = {\n",
+    "    \"LorentzNet\": json.load(open(\"/local/joosep/ml-tau-en-reg/results/240524_cosinescheduler/dm_multiclass/LorentzNet/history.json\")),\n",
+    "    \"SimpleDNN\": json.load(open(\"/local/joosep/ml-tau-en-reg/results/240524_cosinescheduler/dm_multiclass/SimpleDNN/history.json\")),\n",
+    "    \"ParticleTransformer\": json.load(open(\"/local/joosep/ml-tau-en-reg/results/240524_cosinescheduler/dm_multiclass/ParticleTransformer/history.json\")),\n",
+    "}"
    ]
   },
   {
@@ -95,15 +52,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "training_type = \"jet_regression\"\n",
-    "training_title = \"$p_T$ regression\"\n",
-    "ylim_train = 0.02\n",
-    "ylim_valid = 0.02\n",
+    "# training_type = \"jet_regression\"\n",
+    "# training_title = \"$p_T$ regression\"\n",
+    "# ylim = 0.02\n",
     "\n",
-    "# training_type = \"dm_multiclass\"\n",
-    "# training_title = \"Decay mode classification\"\n",
-    "# ylim_train = 1.0\n",
-    "# ylim_valid = 1.0"
+    "training_type = \"dm_multiclass\"\n",
+    "training_title = \"Decay mode classification\"\n",
+    "ylim = 1.0\n"
    ]
   },
   {
@@ -113,41 +68,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plt.plot(loss_train[(training_type, \"ParticleTransformer\")], label=\"ParticleTransformer\")\n",
-    "plt.plot(loss_train[(training_type, \"LorentzNet\")], label=\"LorentzNet\")\n",
-    "plt.plot(loss_train[(training_type, \"SimpleDNN\")], label=\"SimpleDNN\")\n",
-    "plt.ylim(0.0, ylim_train)\n",
-    "plt.legend(loc=\"best\")\n",
-    "plt.ylabel(\"Training loss\")\n",
+    "c = plt.plot(losses[training_type][\"ParticleTransformer\"][\"losses_train\"], ls=\"--\", lw=1)[0]\n",
+    "plt.plot(losses[training_type][\"ParticleTransformer\"][\"losses_validation\"], label=\"ParticleTransformer\", color=c.get_color())\n",
+    "\n",
+    "c = plt.plot(losses[training_type][\"LorentzNet\"][\"losses_train\"], ls=\"--\", lw=1)[0]\n",
+    "plt.plot(losses[training_type][\"LorentzNet\"][\"losses_validation\"], label=\"LorentzNet\", color=c.get_color())\n",
+    "\n",
+    "c = plt.plot(losses[training_type][\"SimpleDNN\"][\"losses_train\"], ls=\"--\", lw=1)[0]\n",
+    "plt.plot(losses[training_type][\"SimpleDNN\"][\"losses_validation\"], label=\"DeepSet\", color=c.get_color())\n",
+    "\n",
+    "plt.ylim(0.0, ylim)\n",
+    "plt.legend(loc=\"best\", title=\"Validation\")\n",
+    "plt.ylabel(\"Loss\")\n",
     "plt.xlabel(\"Training epoch\")\n",
     "plt.title(training_title)\n",
-    "plt.savefig(outdir + \"/train_loss_{}.pdf\".format(training_type))"
+    "plt.savefig(outdir + \"/loss_{}.pdf\".format(training_type))"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c89ca3d2-b471-4e1c-aff4-19b90fb6d37c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "plt.plot(loss_valid[(training_type, \"ParticleTransformer\")], label=\"ParticleTransformer\")\n",
-    "plt.plot(loss_valid[(training_type, \"LorentzNet\")], label=\"LorentzNet\")\n",
-    "plt.plot(loss_valid[(training_type, \"SimpleDNN\")], label=\"SimpleDNN\")\n",
-    "plt.ylim(0.0, ylim_valid)\n",
-    "plt.legend(loc=\"best\")\n",
-    "plt.ylabel(\"Validation loss\")\n",
-    "plt.xlabel(\"Training epoch\")\n",
-    "plt.savefig(outdir + \"/valid_loss_{}.pdf\".format(training_type))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "769364c5-4998-4e8b-bcdc-6b141e0aad7a",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/losses.ipynb
+++ b/notebooks/losses.ipynb
@@ -95,15 +95,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# training_type = \"jet_regression\"\n",
-    "# training_title = \"$p_T$ regression\"\n",
-    "# ylim_train = 0.02\n",
-    "# ylim_valid = 0.02\n",
+    "training_type = \"jet_regression\"\n",
+    "training_title = \"$p_T$ regression\"\n",
+    "ylim_train = 0.02\n",
+    "ylim_valid = 0.02\n",
     "\n",
-    "training_type = \"dm_multiclass\"\n",
-    "training_title = \"Decay mode classification\"\n",
-    "ylim_train = 0.5\n",
-    "ylim_valid = 0.05"
+    "# training_type = \"dm_multiclass\"\n",
+    "# training_title = \"Decay mode classification\"\n",
+    "# ylim_train = 1.0\n",
+    "# ylim_valid = 1.0"
    ]
   },
   {
@@ -131,15 +131,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plt.plot(loss_valid[(\"jet_regression\", \"ParticleTransformer\")], label=\"ParticleTransformer\")\n",
-    "plt.plot(loss_valid[(\"jet_regression\", \"LorentzNet\")], label=\"LorentzNet\")\n",
-    "plt.plot(loss_valid[(\"jet_regression\", \"SimpleDNN\")], label=\"SimpleDNN\")\n",
+    "plt.plot(loss_valid[(training_type, \"ParticleTransformer\")], label=\"ParticleTransformer\")\n",
+    "plt.plot(loss_valid[(training_type, \"LorentzNet\")], label=\"LorentzNet\")\n",
+    "plt.plot(loss_valid[(training_type, \"SimpleDNN\")], label=\"SimpleDNN\")\n",
     "plt.ylim(0.0, ylim_valid)\n",
     "plt.legend(loc=\"best\")\n",
     "plt.ylabel(\"Validation loss\")\n",
     "plt.xlabel(\"Training epoch\")\n",
     "plt.savefig(outdir + \"/valid_loss_{}.pdf\".format(training_type))"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "769364c5-4998-4e8b-bcdc-6b141e0aad7a",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/validate.ipynb
+++ b/notebooks/validate.ipynb
@@ -106,7 +106,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data_qq = load_sample(\"../data/20240402_full_stats/QCD\", -1)"
+    "data_qq = load_sample(\"/local/joosep/ml-tau-en-reg/ntuples/20240519_qq_and_zh_2M/QCD/\", -1)"
    ]
   },
   {
@@ -116,7 +116,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data_z = load_sample(\"../data/20240402_full_stats/Z_Ztautau\", -1)"
+    "data_z = load_sample(\"/local/joosep/ml-tau-en-reg/ntuples/20240519_qq_and_zh_2M/Z_Ztautau\", -1)"
    ]
   },
   {
@@ -126,7 +126,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data_zh = load_sample(\"../data/20240402_full_stats/ZH_Htautau/\", -1)"
+    "data_zh = load_sample(\"/local/joosep/ml-tau-en-reg/ntuples/20240519_qq_and_zh_2M/ZH_Htautau/\", -1)"
    ]
   },
   {

--- a/run.sh
+++ b/run.sh
@@ -2,5 +2,4 @@
 
 #keras is not used, but for some reason, it's imported somewhere and crashes if this is not specified
 export KERAS_BACKEND=torch
-
 apptainer exec -B /home/laurits,/scratch/persistent,/local/joosep --env PYTHONPATH=`pwd` --nv /home/software/singularity/pytorch.simg\:2024-04-30 "$@"


### PR DESCRIPTION
- due to the overtraining observed in the dm_multiclass and jet_regression tasks, bump the signal statistics
- retraining ongoing into `240522_qq_zh_2m_merged`
- training time <10h for jet_regression and dm_multiclass (on 10g MIG partition on A100)
- use cosine learning rate decay and a lower learning rate (1e-4)
- clip `max_cands` to 16 (fine for signal, but to be increased to 32 for background)
- the final results are in https://github.com/HEP-KBFI/ml-tau-en-reg/pull/21#issuecomment-2132970791
