### PR TITLE
reduce number of layers for ParticleTransformer decay mode classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,16 @@ $ du -csh /scratch/persistent/joosep/ml-tau/20240402_full_stats_merged/*
 101M	/scratch/persistent/joosep/ml-tau/20240402_full_stats_merged/z_train.parquet
 ```
 
+# Results
+```
+5.7M    /local/joosep/ml-tau-en-reg/results/240524_cosinescheduler/dm_multiclass/LorentzNet
+8.1M    /local/joosep/ml-tau-en-reg/results/240528_PT_num_layers_4/dm_multiclass/ParticleTransformer
+6.4M    /local/joosep/ml-tau-en-reg/results/240524_cosinescheduler/dm_multiclass/SimpleDNN
+6.1M    /local/joosep/ml-tau-en-reg/results/240524_cosinescheduler/jet_regression/LorentzNet
+14M     /local/joosep/ml-tau-en-reg/results/240524_cosinescheduler/jet_regression/ParticleTransformer
+6.7M    /local/joosep/ml-tau-en-reg/results/240524_cosinescheduler/jet_regression/SimpleDNN
+```
+
 # Running
 
 All the necessary packages are installed to the singularity image used in the ```run.sh``` script.

--- a/enreg/config/models/ParticleTransformer/ParticleTransformer.yaml
+++ b/enreg/config/models/ParticleTransformer/ParticleTransformer.yaml
@@ -1,3 +1,9 @@
 input_dim: 13
+hyperparameters:
+  num_layers: 8
+  embed_dims:
+    - 128
+    - 512
+    - 128
 defaults:
   - _self_

--- a/enreg/scripts/submit-pytorch-gpu-all.sh
+++ b/enreg/scripts/submit-pytorch-gpu-all.sh
@@ -7,13 +7,13 @@ export OUTDIR=training-outputs/240528_PT_num_layers_4/
 #for regression and decay mode, use only signal (tau) jets
 export TRAIN_SAMPS=zh_train.parquet
 export TEST_SAMPS=z_test.parquet,zh_test.parquet
-# sbatch enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=jet_regression model_type=LorentzNet
-# sbatch enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=jet_regression model_type=ParticleTransformer
-# sbatch enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=jet_regression model_type=SimpleDNN
+sbatch enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=jet_regression model_type=LorentzNet
+sbatch enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=jet_regression model_type=ParticleTransformer
+sbatch enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=jet_regression model_type=SimpleDNN
  
-# sbatch enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=dm_multiclass model_type=LorentzNet
+sbatch enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=dm_multiclass model_type=LorentzNet
 sbatch enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=dm_multiclass model_type=ParticleTransformer models.ParticleTransformer.hyperparameters.num_layers=4
-# sbatch enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=dm_multiclass model_type=SimpleDNN
+sbatch enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=dm_multiclass model_type=SimpleDNN
 
 ##for binary classification, use signal (tau) and background (non-tau) jets
 # export TRAIN_SAMPS=zh_train.parquet,qq_train.parquet

--- a/enreg/scripts/submit-pytorch-gpu-all.sh
+++ b/enreg/scripts/submit-pytorch-gpu-all.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
 
 #edit this as needed
-export OUTDIR=training-outputs/240524_cosinescheduler/
+export OUTDIR=training-outputs/240528_PT_num_layers_4/
 #export OUTDIR=tests
 
 #for regression and decay mode, use only signal (tau) jets
 export TRAIN_SAMPS=zh_train.parquet
 export TEST_SAMPS=z_test.parquet,zh_test.parquet
-sbatch enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=jet_regression model_type=LorentzNet
-sbatch enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=jet_regression model_type=ParticleTransformer
-sbatch enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=jet_regression model_type=SimpleDNN
+# sbatch enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=jet_regression model_type=LorentzNet
+# sbatch enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=jet_regression model_type=ParticleTransformer
+# sbatch enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=jet_regression model_type=SimpleDNN
  
-sbatch enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=dm_multiclass model_type=LorentzNet
-sbatch enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=dm_multiclass model_type=ParticleTransformer
-sbatch enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=dm_multiclass model_type=SimpleDNN
+# sbatch enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=dm_multiclass model_type=LorentzNet
+sbatch enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=dm_multiclass model_type=ParticleTransformer models.ParticleTransformer.hyperparameters.num_layers=4
+# sbatch enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=dm_multiclass model_type=SimpleDNN
 
 ##for binary classification, use signal (tau) and background (non-tau) jets
 # export TRAIN_SAMPS=zh_train.parquet,qq_train.parquet

--- a/enreg/scripts/trainModel.py
+++ b/enreg/scripts/trainModel.py
@@ -35,8 +35,6 @@ from enreg.tools.models.LorentzNet import LorentzNet
 from enreg.tools.data_management.features import FeatureStandardization
 
 from enreg.tools.data_management.particleTransformer_dataset import ParticleTransformerDataset
-from enreg.tools.data_management.lorentzNet_dataset import LorentzNetDataset
-from enreg.tools.data_management.simpleDNN_dataset import DeepSetDataset
 
 from enreg.tools.models.logTrainingProgress import logTrainingProgress, logTrainingProgress_regression
 from enreg.tools.models.logTrainingProgress import logTrainingProgress_decaymode
@@ -310,6 +308,8 @@ def trainModel(cfg: DictConfig) -> None:
         model = ParticleTransformer(
             input_dim=input_dim,
             num_classes=num_classes,
+            num_layers=cfg.models.ParticleTransformer.hyperparameters.num_layers,
+            embed_dims=cfg.models.ParticleTransformer.hyperparameters.embed_dims,
             use_pre_activation_pair=False,
             for_inference=False,
             use_amp=False,

--- a/notebooks/losses.ipynb
+++ b/notebooks/losses.ipynb
@@ -27,6 +27,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "8d540de4-fc08-4479-af4e-42ba271ede79",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!ls /local/joosep/ml-tau-en-reg/results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "c02e1198-6332-42da-b889-b30de72c32b7",
    "metadata": {},
    "outputs": [],
@@ -41,7 +51,7 @@
     "losses[\"dm_multiclass\"] = {\n",
     "    \"LorentzNet\": json.load(open(\"/local/joosep/ml-tau-en-reg/results/240524_cosinescheduler/dm_multiclass/LorentzNet/history.json\")),\n",
     "    \"SimpleDNN\": json.load(open(\"/local/joosep/ml-tau-en-reg/results/240524_cosinescheduler/dm_multiclass/SimpleDNN/history.json\")),\n",
-    "    \"ParticleTransformer\": json.load(open(\"/local/joosep/ml-tau-en-reg/results/240524_cosinescheduler/dm_multiclass/ParticleTransformer/history.json\")),\n",
+    "    \"ParticleTransformer\": json.load(open(\"/local/joosep/ml-tau-en-reg/results/240528_PT_num_layers_4/dm_multiclass/ParticleTransformer/history.json\")),\n",
     "}"
    ]
   },
@@ -84,6 +94,14 @@
     "plt.title(training_title)\n",
     "plt.savefig(outdir + \"/loss_{}.pdf\".format(training_type))"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1105abe0-3857-4446-a475-7fe7e6a727c5",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Made the number of layers of ParticleTransformer configurable, reduce from 8->4.
This improves the both the training and validation loss a lot, validation is now decreasing stably as expected:
<img width="914" alt="Screenshot 2024-05-28 at 12 20 13" src="https://github.com/HEP-KBFI/ml-tau-en-reg/assets/69717/c95e4d5c-be7e-40d0-89aa-d35e13cd1a82">


Now the final plot looks like this:
![image](https://github.com/HEP-KBFI/ml-tau-en-reg/assets/69717/5a19f6c7-ca8d-44c3-9f31-7093cc8689ee)

