### PR TITLE
feature sets for other models, improve memory usage, cleanup old stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,12 +100,3 @@ To produce the jet-based ML ntuples from the .root and .hepmc files
 ./run.sh python3 enreg/scripts/ntupelize_edm4hep.py
 bash /home/joosep/tmp/NA7VJ17OVH/executables/execute0.sh  
 ```
-
-# Contributing
-
-Contributing to the project has the following requirements:
-
-- Document each functionality you add (i.e., docstrings for each function you add)
-- Follow the PEP8 guidelines
-- Create a new branch when making edits and create a Pull Request (PR) for it to be merged to the `main` branch. Direct pushes to the `main` branch are disabled.
-- Recommended: Add unit tests for the functionality

--- a/enreg/config/model_training.yaml
+++ b/enreg/config/model_training.yaml
@@ -56,6 +56,7 @@ training:
   num_epochs: 100
   batch_size: 1024
   num_dataloader_workers: 2
+  prefetch_factor: 100
   classweight_sig: 1
   classweight_bgr: 10
   use_class_weights: True

--- a/enreg/config/model_training.yaml
+++ b/enreg/config/model_training.yaml
@@ -43,14 +43,7 @@ dataset:
   min_jet_pt: 0
   max_jet_pt: 1000
   feature_set:
-    - cand_kinematics
-    - cand_features
-    - cand_lifetimes
-
-  #for LorentzNet
-  beams:
-    add: True
-    mass: 1.0
+    - cand_ParT_features
 
 #number of output classes for different tasks
 num_classes:
@@ -74,14 +67,15 @@ training:
   slow_optimizer: None
   verbosity: 1
 
-#This has not been tested!
-feature_standardization:
-  standardize_inputs: False
-  method: "mean_rms"
-  features:
-    - cand_features
-    - cand_kinematics
-
-defaults:
+#disable creation of the outputs dir which we don't use
+#https://stackoverflow.com/questions/65104134/disable-file-output-of-hydra
+defaults:  
   - models: models
-  - _self_
+  - _self_ 
+  - override hydra/hydra_logging: disabled  
+  - override hydra/job_logging: disabled  
+
+hydra:  
+  output_subdir: null  
+  run:  
+    dir: .

--- a/enreg/config/models/LorentzNet/LorentzNet.yaml
+++ b/enreg/config/models/LorentzNet/LorentzNet.yaml
@@ -1,4 +1,3 @@
-input_dim: 13
 hyperparameters:
   n_hidden: 72
   dropout: 0.2

--- a/enreg/config/models/ParticleTransformer/ParticleTransformer.yaml
+++ b/enreg/config/models/ParticleTransformer/ParticleTransformer.yaml
@@ -1,4 +1,3 @@
-input_dim: 13
 hyperparameters:
   num_layers: 2
   embed_dims:

--- a/enreg/config/models/SimpleDNN/SimpleDNN.yaml
+++ b/enreg/config/models/SimpleDNN/SimpleDNN.yaml
@@ -1,3 +1,2 @@
-input_dim: 17
 defaults:
   - _self_

--- a/enreg/scripts/submit-pytorch-gpu-all.sh
+++ b/enreg/scripts/submit-pytorch-gpu-all.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 
+
 #for regression and decay mode, use only signal (tau) jets
 export TRAIN_SAMPS=z_train.parquet
 export TEST_SAMPS=z_test.parquet,zh_test.parquet
 for i in `seq 1 1`; do
-    export OUTDIR=training-outputs/20240701_lowered_ptcut_merged/v$i
+    export OUTDIR=training-outputs/240710_memopt/v$i
     sbatch enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=jet_regression model_type=LorentzNet
     sbatch enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=jet_regression model_type=ParticleTransformer
     sbatch enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=jet_regression model_type=SimpleDNN
@@ -14,12 +15,12 @@ for i in `seq 1 1`; do
     sbatch enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=dm_multiclass model_type=SimpleDNN
 done
 
-##for binary classification, use signal (tau) and background (non-tau) jets
-# export TRAIN_SAMPS=zh_train.parquet,qq_train.parquet
-# export TEST_SAMPS=z_test.parquet,zh_test.parquet,qq_test.parquet
-# for i in `seq 1 5`; do
-#     export OUTDIR=training-outputs/240618_binarycls/v$i
-#     #sbatch --mem-per-gpu 150G enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=binary_classification model_type=LorentzNet
-#     #sbatch --mem-per-gpu 150G enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=binary_classification model_type=ParticleTransformer models.ParticleTransformer.hyperparameters.num_layers=8
-#     sbatch --mem-per-gpu 150G enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=binary_classification model_type=SimpleDNN
-# done
+#for binary classification, use signal (tau) and background (non-tau) jets
+export TRAIN_SAMPS=z_train.parquet,qq_train.parquet
+export TEST_SAMPS=z_test.parquet,zh_test.parquet,qq_test.parquet
+for i in `seq 1 1`; do
+    export OUTDIR=training-outputs/240710_memopt/v$i
+    sbatch enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=binary_classification model_type=LorentzNet dataset.max_cands=32 training.batch_size=512
+    sbatch enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=binary_classification model_type=ParticleTransformer dataset.max_cands=32 training.batch_size=512
+    sbatch enreg/scripts/train-pytorch-gpu.sh output_dir=$OUTDIR training_samples=[$TRAIN_SAMPS] test_samples=[$TEST_SAMPS] training_type=binary_classification model_type=SimpleDNN dataset.max_cands=32 training.batch_size=512
+done

--- a/enreg/scripts/train-pytorch-gpu.sh
+++ b/enreg/scripts/train-pytorch-gpu.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #SBATCH -p gpu
-#SBATCH --gres gpu:rtx
-#SBATCH --mem-per-gpu 40G
+#SBATCH --gres gpu:mig:1
+#SBATCH --mem-per-gpu 30G
 #SBATCH -o logs/slurm-%x-%j-%N.out
 
 env | grep CUDA

--- a/enreg/scripts/trainModel.py
+++ b/enreg/scripts/trainModel.py
@@ -41,45 +41,18 @@ from enreg.tools.models.logTrainingProgress import logTrainingProgress_decaymode
 
 import time
 
-def unpack_ParticleTransformer_data(X, dev, feature_set):
-    cand_features = X["cand_features"].to(device=dev)
-    cand_kinematics = X["cand_kinematics"].to(device=dev)
-    mask = X["mask"].to(device=dev)
-    return cand_features, cand_kinematics, mask
-
-def unpack_LorentzNet_data(X, dev, feature_set):
-    cand_kinematics = X["cand_kinematics"].to(device=dev)
-    beam_kinematics = X["beam_kinematics"].to(device=dev)
-    kinematics = torch.swapaxes(torch.concatenate([beam_kinematics, cand_kinematics], axis=-1), 1, 2)
-
-    cand_features = X["cand_features"].to(device=dev)
-    beam_features = X["beam_features"].to(device=dev)
-    scalars = torch.swapaxes(torch.concatenate([beam_features, cand_features], axis=-1), 1, 2)
-
-    cand_mask = X["mask"].to(device=dev)
-    beam_mask = X["beam_mask"].to(device=dev)
-    mask = torch.swapaxes(torch.concatenate([beam_mask, cand_mask], axis=-1), 1, 2)
-    return kinematics, scalars, mask
-
-
-
-def unpack_SimpleDNN_data(X, dev, feature_set):
+def unpack_data(X, dev, feature_set):
     # Create a dictionary for each feature
     features_as_dict = {
-        feature: torch.swapaxes(X[feature].to(device=dev), 1, 2) for feature in feature_set
+        feature: X[feature].to(device=dev) for feature in feature_set
     }
-    cand_mask = torch.swapaxes(X["mask"].to(device=dev), 1, 2)
-    
-    # Concatenate chosen features
-    pfs = torch.cat([features_as_dict[feat] for feat in feature_set], axis=-1)
-    
-    return pfs, cand_mask
 
-dataset_unpackers = {
-    "ParticleTransformer": unpack_ParticleTransformer_data,
-    "LorentzNet": unpack_LorentzNet_data,
-    "SimpleDNN": unpack_SimpleDNN_data,
-}
+    # Concatenate chosen features
+    particle_features = torch.cat([features_as_dict[feat] for feat in feature_set], axis=1)
+
+    cand_kinematics = X["cand_kinematics"].to(device=dev)
+    mask = X["mask"].to(device=dev).bool()
+    return particle_features, cand_kinematics, mask
 
 class EarlyStopper:
     def __init__(self, patience=1, min_delta=0):
@@ -127,7 +100,6 @@ def get_weights(train_dataset, validation_dataset, n_bins=20):
 def train_loop(
     idx_epoch,
     dataloader_train,
-    transform,
     model,
     dev,
     loss_fn,
@@ -135,7 +107,6 @@ def train_loop(
     optimizer,
     lr_scheduler,
     tensorboard,
-    dataset_unpacker,
     feature_set,
     num_classes,
     kind="jet_regression",
@@ -173,9 +144,7 @@ def train_loop(
 
     for idx_batch, (X, y, weight) in tqdm.tqdm(enumerate(dataloader_train), total=len(dataloader_train)):
         # Compute prediction and loss
-        if transform:
-            X = transform(X)
-        model_inputs = dataset_unpacker(X, dev, feature_set)
+        model_inputs = unpack_data(X, dev, feature_set)
         y_for_loss = y[kind].to(device=dev)
         weight = weight.to(device=dev)
 
@@ -270,13 +239,13 @@ def run_command(cmd):
 
 @hydra.main(config_path="../config", config_name="model_training", version_base=None)
 def trainModel(cfg: DictConfig) -> None:
+    print("<trainModel>:")
 
     #because we are doing plots for tensorboard, we don't want anything to crash
     plt.switch_backend('agg')
 
     feature_set = cfg.dataset.feature_set
-    print("\nUsing features: ", feature_set,'\n')
-    print("<trainModel>:")
+    print(f"Using features: {feature_set}")
 
     kind = cfg.training_type
     model_config = cfg.models[cfg.model_type]
@@ -324,9 +293,15 @@ def trainModel(cfg: DictConfig) -> None:
     print("Using device: {}".format(dev))
 
     print("Building model...")
-    input_dim = model_config.input_dim
-    if cfg.dataset.use_lifetime:
+
+    input_dim = 0
+    if 'cand_kinematics' in feature_set:
         input_dim += 4
+    if 'cand_features' in feature_set:
+        input_dim += 13
+    if 'cand_lifetimes' in feature_set:
+        input_dim += 4
+    
     num_classes = cfg.num_classes[kind]
     if cfg.model_type == "ParticleTransformer":
         model = ParticleTransformer(
@@ -351,14 +326,6 @@ def trainModel(cfg: DictConfig) -> None:
             verbosity=cfg.verbosity,
         ).to(device=dev)
     elif cfg.model_type == "SimpleDNN": # Input dim changes 
-        input_dim = 0
-        if 'cand_kinematics' in feature_set:
-            input_dim += 4
-        if 'cand_features' in feature_set:
-            input_dim += 13
-        if 'cand_lifetimes' in feature_set:
-            input_dim += 4
-            
         model = DeepSet(input_dim, num_classes).to(device=dev)
 
     initWeights(model)
@@ -385,17 +352,6 @@ def trainModel(cfg: DictConfig) -> None:
             prefetch_factor=10,
             shuffle=True
         )
-
-        transform = None
-        if cfg.feature_standardization.standardize_inputs:
-            transform = FeatureStandardization(
-                method=cfg.feature_standardization.method,
-                features=ccfg.feature_standardization.features,
-                feature_dim=1,
-                verbosity=cfg.verbosity,
-            )
-            transform.compute_params(dataloader_train)
-            transform.save_params(os.path.join(model_output_path, "feature_transform.json"))
 
         if kind == "binary_classification":
             if cfg.training.use_class_weights:
@@ -456,7 +412,6 @@ def trainModel(cfg: DictConfig) -> None:
             loss_train = train_loop(
                 idx_epoch,
                 dataloader_train,
-                transform,
                 model,
                 dev,
                 loss_fn,
@@ -464,7 +419,6 @@ def trainModel(cfg: DictConfig) -> None:
                 optimizer,
                 lr_scheduler,
                 tensorboard,
-                dataset_unpackers[cfg.model_type],
                 feature_set,
                 num_classes,
                 kind=kind
@@ -476,7 +430,6 @@ def trainModel(cfg: DictConfig) -> None:
                 loss_validation = train_loop(
                     idx_epoch,
                     dataloader_validation,
-                    transform,
                     model,
                     dev,
                     loss_fn,
@@ -484,7 +437,6 @@ def trainModel(cfg: DictConfig) -> None:
                     None,
                     None,
                     tensorboard,
-                    dataset_unpackers[cfg.model_type],
                     feature_set,
                     num_classes,
                     kind=kind,
@@ -534,7 +486,7 @@ def trainModel(cfg: DictConfig) -> None:
             preds = []
             targets = []
             for (X, y, weight) in tqdm.tqdm(dataloader_full, total=len(dataloader_full)):
-                model_inputs = dataset_unpackers[cfg.model_type](X, dev, feature_set)
+                model_inputs = unpack_data(X, dev, feature_set)
                 y_for_loss = y[kind]
                 with torch.no_grad():
                     if kind == "jet_regression":

--- a/enreg/scripts/trainModel.py
+++ b/enreg/scripts/trainModel.py
@@ -297,7 +297,7 @@ def trainModel(cfg: DictConfig) -> None:
     input_dim = 0
     if 'cand_kinematics' in feature_set:
         input_dim += 4
-    if 'cand_features' in feature_set:
+    if 'cand_ParT_features' in feature_set:
         input_dim += 13
     if 'cand_lifetimes' in feature_set:
         input_dim += 4

--- a/enreg/tools/data_management/particleTransformer_dataset.py
+++ b/enreg/tools/data_management/particleTransformer_dataset.py
@@ -6,10 +6,12 @@ import awkward as ak
 import enreg.tools.general as g
 from omegaconf import OmegaConf
 from omegaconf import DictConfig
-from torch.utils.data import Dataset
+from torch.utils.data import IterableDataset
 from torch import nn
 import enreg.tools.data_management.features as f
 from enreg.tools.models.ParticleTransformer import ParticleTransformer
+
+from collections.abc import Sequence
 
 def stack_and_pad_features(cand_features, max_cands):
     cand_features_tensors = np.stack([ak.pad_none(cand_features[feat], max_cands, clip=True) for feat in cand_features.fields], axis=-1)
@@ -21,51 +23,44 @@ def stack_and_pad_features(cand_features, max_cands):
     cand_features_tensors[np.isinf(cand_features_tensors)] = 0
     return cand_features_tensors
 
+def load_row_groups(filename):
+    metadata = ak.metadata_from_parquet(filename)
+    num_row_groups = metadata["num_row_groups"]
+    col_counts = metadata["col_counts"]
+    return [RowGroup(filename, row_group, col_counts[row_group]) for row_group in range(num_row_groups)]
 
-class ParticleTransformerDataset(Dataset):
-    def __init__(self, data: ak.Array, cfg: DictConfig, do_preselection=True):
-        self.data = data
+class RowGroup:
+    def __init__(self, filename, row_group, num_rows):
+        self.filename = filename
+        self.row_group = row_group
+        self.num_rows = num_rows
+
+class ParticleTransformerDataset(IterableDataset):
+    def __init__(self, row_groups: Sequence[RowGroup], cfg: DictConfig):
+        self.row_groups = row_groups
         self.cfg = cfg
-        if do_preselection:
-            self.preselection()
-        self.num_jets = len(self.data.reco_jet_p4s)
-        self.build_tensors()
+        self.num_rows = sum([rg.num_rows for rg in self.row_groups])
 
-    def preselection(self):
-        print("ParticleTransformer.preselection")
-        """Chooses jets based on preselection criteria specified in the configuration"""
-        jet_constituent_p4s = g.reinitialize_p4(self.data.reco_cand_p4s)
-        jet_p4s = g.reinitialize_p4(self.data.reco_jet_p4s)
-        no_mask = ak.ones_like(self.data.gen_jet_tau_decaymode, dtype=bool)
-        min_jet_theta_mask = no_mask if self.cfg.min_jet_theta == -1 else jet_p4s.theta >= self.cfg.min_jet_theta
-        max_jet_theta_mask = no_mask if self.cfg.max_jet_theta == -1 else jet_p4s.theta <= self.cfg.max_jet_theta
-        min_jet_pt_mask = no_mask if self.cfg.min_jet_pt == -1 else jet_p4s.pt >= self.cfg.min_jet_pt
-        max_jet_pt_mask = no_mask if self.cfg.max_jet_pt == -1 else jet_p4s.pt <= self.cfg.max_jet_pt
-        preselection_mask = min_jet_theta_mask * max_jet_theta_mask * min_jet_pt_mask * max_jet_pt_mask
-        print("mask: {}/{}".format(np.sum(preselection_mask), len(preselection_mask)))
-        self.data = ak.Array({field: self.data[field] for field in self.data.fields})[preselection_mask]
-
-    def build_tensors(self):
-        print("ParticleTransformer.build_tensors")
-        jet_constituent_p4s = g.reinitialize_p4(self.data.reco_cand_p4s)
-        self.gen_jet_tau_p4s = g.reinitialize_p4(self.data.gen_jet_tau_p4s)
-        self.jet_p4s = g.reinitialize_p4(self.data.reco_jet_p4s)
+    def build_tensors(self, data: ak.Array):
+        jet_constituent_p4s = g.reinitialize_p4(data.reco_cand_p4s)
+        gen_jet_tau_p4s = g.reinitialize_p4(data.gen_jet_tau_p4s)
+        jet_p4s = g.reinitialize_p4(data.reco_jet_p4s)
 
         #ParticleTransformer features from https://arxiv.org/pdf/2404.16091, table X
         cand_ParT_features = ak.Array({
-            "cand_deta": f.deltaEta(jet_constituent_p4s.eta, self.jet_p4s.eta),
-            "cand_dphi": f.deltaPhi(jet_constituent_p4s.phi, self.jet_p4s.phi),
+            "cand_deta": f.deltaEta(jet_constituent_p4s.eta, jet_p4s.eta),
+            "cand_dphi": f.deltaPhi(jet_constituent_p4s.phi, jet_p4s.phi),
             "cand_logpt": np.log(jet_constituent_p4s.pt),
             "cand_loge": np.log(jet_constituent_p4s.energy),
-            "cand_logptrel": np.log(jet_constituent_p4s.pt / self.jet_p4s.pt),
-            "cand_logerel": np.log(jet_constituent_p4s.energy / self.jet_p4s.energy),
-            "cand_deltaR": f.deltaR_etaPhi(jet_constituent_p4s.eta, jet_constituent_p4s.phi, self.jet_p4s.eta, self.jet_p4s.phi),
-            "cand_charge": self.data.reco_cand_charge,
-            "isElectron": ak.values_astype(abs(self.data.reco_cand_pdg) == 11, np.float32),
-            "isMuon": ak.values_astype(abs(self.data.reco_cand_pdg) == 13, np.float32),
-            "isPhoton": ak.values_astype(abs(self.data.reco_cand_pdg) == 22, np.float32),
-            "isChargedHadron": ak.values_astype(abs(self.data.reco_cand_pdg) == 211, np.float32),
-            "isNeutralHadron": ak.values_astype(abs(self.data.reco_cand_pdg) == 130, np.float32),
+            "cand_logptrel": np.log(jet_constituent_p4s.pt / jet_p4s.pt),
+            "cand_logerel": np.log(jet_constituent_p4s.energy / jet_p4s.energy),
+            "cand_deltaR": f.deltaR_etaPhi(jet_constituent_p4s.eta, jet_constituent_p4s.phi, jet_p4s.eta, jet_p4s.phi),
+            "cand_charge": data.reco_cand_charge,
+            "isElectron": ak.values_astype(abs(data.reco_cand_pdg) == 11, np.float32),
+            "isMuon": ak.values_astype(abs(data.reco_cand_pdg) == 13, np.float32),
+            "isPhoton": ak.values_astype(abs(data.reco_cand_pdg) == 22, np.float32),
+            "isChargedHadron": ak.values_astype(abs(data.reco_cand_pdg) == 211, np.float32),
+            "isNeutralHadron": ak.values_astype(abs(data.reco_cand_pdg) == 130, np.float32),
         })
 
         #raw particle kinematics, for LorentzNet and ParticleTransformer (attention matrix calculation)
@@ -78,78 +73,88 @@ class ParticleTransformerDataset(Dataset):
 
         #additional track lifetime variables
         cand_lifetimes = ak.Array({
-            "cand_dz": self.data.reco_cand_dz,
-            "cand_dz_err": self.data.reco_cand_dz_err,
-            "cand_dxy": self.data.reco_cand_dxy,
-            "cand_dxy_err": self.data.reco_cand_dxy_err
+            "cand_dz": data.reco_cand_dz,
+            "cand_dz_err": data.reco_cand_dz_err,
+            "cand_dxy": data.reco_cand_dxy,
+            "cand_dxy_err": data.reco_cand_dxy_err
         })
 
-        print("creating padded tensors")
         cand_ParT_features_tensors = stack_and_pad_features(cand_ParT_features, self.cfg.max_cands)
         cand_kinematics_tensors = stack_and_pad_features(cand_kinematics, self.cfg.max_cands)
         cand_lifetimes_tensors = stack_and_pad_features(cand_lifetimes, self.cfg.max_cands)
 
-        self.cand_ParT_features_tensors = torch.tensor(cand_ParT_features_tensors, dtype=torch.float32)
-        self.cand_kinematics_tensors = torch.tensor(cand_kinematics_tensors, dtype=torch.float32)
-        self.cand_lifetimes_tensors = torch.tensor(cand_lifetimes_tensors, dtype=torch.float32)
-        
-        print(
-            "cand_ParT_features_tensors={} cand_kinematics_tensors={} self.cand_lifetimes_tensors={}".format(
-                self.cand_ParT_features_tensors.shape,
-                self.cand_kinematics_tensors.shape,
-                self.cand_lifetimes_tensors.shape
-            )
-        )
+        cand_ParT_features_tensors = torch.tensor(cand_ParT_features_tensors, dtype=torch.float32)
+        cand_kinematics_tensors = torch.tensor(cand_kinematics_tensors, dtype=torch.float32)
+        cand_lifetimes_tensors = torch.tensor(cand_lifetimes_tensors, dtype=torch.float32)
 
-        print("creating mask")
-        self.node_mask_tensors = torch.unsqueeze(
+        node_mask_tensors = torch.unsqueeze(
             torch.tensor(
-                ak.to_numpy(ak.fill_none(ak.pad_none(ak.ones_like(self.data.reco_cand_pdg), self.cfg.max_cands, clip=True), 0,)),
+                ak.to_numpy(ak.fill_none(ak.pad_none(ak.ones_like(data.reco_cand_pdg), self.cfg.max_cands, clip=True), 0,)),
                 dtype=torch.float32
             ),
             dim=1
         )
-        print("node_mask_tensors={}".format(self.node_mask_tensors.shape))
 
-        print("creating weights")
-        if not "weight" in self.data.fields:
-            self.weight_tensors = torch.tensor(ak.ones_like(self.data.gen_jet_tau_decaymode), dtype=torch.float32)
+        if not "weight" in data.fields:
+            weight_tensors = torch.tensor(ak.ones_like(data.gen_jet_tau_decaymode), dtype=torch.float32)
         else:
-            self.weight_tensors = torch.tensor(ak.to_numpy(self.data.weight), dtype=torch.float32)
-        print("weight_tensors={}".format(self.weight_tensors))
-        print("weight_tensors values: {}".format(self.weight_tensors[:10]))
+            weight_tensors = torch.tensor(ak.to_numpy(data.weight), dtype=torch.float32)
 
-        self.reco_jet_pt = torch.tensor(ak.to_numpy(self.jet_p4s.pt), dtype=torch.float32)
-        self.reco_jet_energy = torch.tensor(ak.to_numpy(self.jet_p4s.energy), dtype=torch.float32)
+        reco_jet_pt = torch.tensor(ak.to_numpy(jet_p4s.pt), dtype=torch.float32)
+        gen_tau_pt = torch.tensor(ak.to_numpy(gen_jet_tau_p4s.pt), dtype=torch.float32)
+        reco_jet_energy = torch.tensor(ak.to_numpy(jet_p4s.energy), dtype=torch.float32)
 
-        self.jet_regression_target = torch.log(torch.tensor(ak.to_numpy(self.gen_jet_tau_p4s.pt/self.reco_jet_pt), dtype=torch.float32))
-        self.gen_jet_tau_decaymode = torch.tensor(ak.to_numpy(self.data.gen_jet_tau_decaymode)).long()
-        self.gen_jet_tau_decaymode_exists = (self.gen_jet_tau_decaymode != -1).long()
-        print("ParticleTransformer.build_tensors done")
+        jet_regression_target = torch.log(gen_tau_pt/reco_jet_pt)
+        gen_jet_tau_decaymode = torch.tensor(ak.to_numpy(data.gen_jet_tau_decaymode)).long()
+        gen_jet_tau_decaymode_exists = (gen_jet_tau_decaymode != -1).long()
+
+        #X, y, w
+        return (
+            #X - model inputs
+            {
+                "cand_kinematics": cand_kinematics_tensors,
+                "cand_ParT_features": cand_ParT_features_tensors,
+                "cand_lifetimes": cand_lifetimes_tensors,
+                "mask": node_mask_tensors,
+                "reco_jet_pt": reco_jet_pt,
+            },
+
+            #y - targets
+            {
+                "reco_jet_pt": reco_jet_pt,
+                "gen_tau_pt": gen_tau_pt,
+                "jet_regression": jet_regression_target,
+                "binary_classification": gen_jet_tau_decaymode_exists,
+                "dm_multiclass": gen_jet_tau_decaymode
+            },
+
+            #weights
+            weight_tensors
+        )
 
     def __len__(self):
-        return self.num_jets
+        return self.num_rows
 
-    def __getitem__(self, idx):
-        if idx < self.num_jets:
-            return (
-                {
-                    "cand_kinematics": self.cand_kinematics_tensors[idx],
-                    "cand_ParT_features": self.cand_ParT_features_tensors[idx],
-                    "cand_lifetimes": self.cand_lifetimes_tensors[idx],
-
-                    "mask": self.node_mask_tensors[idx],
-
-                    "reco_jet_pt": self.reco_jet_pt[idx],
-                },
-                {
-                    "reco_jet_pt": self.reco_jet_pt[idx],
-                    "gen_tau_pt": self.gen_jet_tau_p4s[idx].pt,
-                    "jet_regression": self.jet_regression_target[idx],
-                    "binary_classification": self.gen_jet_tau_decaymode_exists[idx],
-                    "dm_multiclass": self.gen_jet_tau_decaymode[idx]
-                },
-                self.weight_tensors[idx],
-            )
+    def __iter__(self):
+        worker_info = torch.utils.data.get_worker_info()
+        if worker_info is None:
+            row_groups_to_process = self.row_groups
         else:
-            raise RuntimeError("Invalid idx = %i (num_jets = %i) !!" % (idx, self.num_jets))
+            per_worker = int(math.ceil(float(len(self.row_groups)) / float(worker_info.num_workers)))
+            worker_id = worker_info.id
+            row_groups_start = worker_id*per_worker
+            row_groups_end = row_groups_start + per_worker
+            row_groups_to_process = self.row_groups[row_groups_start:row_groups_end]
+
+        for row_group in row_groups_to_process:
+            #load one chunk from one file
+            data = ak.from_parquet(row_group.filename, row_groups=[row_group.row_group])
+            tensors = self.build_tensors(data)
+
+            #return individual jets from the dataset
+            for ijet in range(len(data)):
+                yield (
+                    {k: v[ijet] for k, v in tensors[0].items()},
+                    {k: v[ijet] for k, v in tensors[1].items()},
+                    tensors[2][ijet],
+                    )

--- a/enreg/tools/models/SimpleDNN.py
+++ b/enreg/tools/models/SimpleDNN.py
@@ -33,9 +33,16 @@ class DeepSet(nn.Module):
         self.nn_pf_embedding = ffn(self.num_pf_features, self.embedding_dim, self.width, self.act, self.dropout)
         self.nn_pred = ffn(self.embedding_dim, num_outputs, self.width, self.act, self.dropout)
 
-    def forward(self, pfs_pad, pfs_mask):
-        pf_encoded = self.act_obj(self.nn_pf_embedding(pfs_pad))*pfs_mask
-        num_pfs = torch.sum(pfs_mask, axis=1)
+    def forward(self, cand_features, cand_kinematics, cand_mask):
+        # cand_features: (N=num_batches, C=num_features, P=num_particles)
+        # cand_kinematics_pxpypze: (N, 4, P) [px,py,pz,energy]
+        # cand_mask: (N, 1, P) -- real particle = 1, padded = 0
+        cand_kinematics = torch.swapaxes(cand_kinematics, 1, 2) #(N, 4, P) -> (N, P, 4)
+        cand_features = torch.swapaxes(cand_features, 1, 2) #(N, C, P) -> (N, P, C)
+        cand_mask = torch.swapaxes(cand_mask, 1, 2) #(N, 1, P) -> (N, P, 1)
+
+        pf_encoded = self.act_obj(self.nn_pf_embedding(cand_features))*cand_mask
+        num_pfs = torch.sum(cand_mask, axis=1)
         jet_encoded1 = self.act_obj(torch.sum(pf_encoded, axis=1)/num_pfs)
         ret = self.nn_pred(jet_encoded1)
         return ret


### PR DESCRIPTION
- follow-up to #62, implement feature set configuration for ParticleTransformer and LorentzNet
- unify model forward interfaces
- simplify ParticleTransformer by removing SequenceTrimmer and uu
- clean up unused / old / untested feature standardization and `use_lifetime`
- move beam stuff from the dataset to LorentzNet implementation, as it's an internal detail of the model
- disable creation of unused and confusing "outputs" dir
- rename `cand_features` -> `cand_ParT_features` for clarity, this is the default feature set as in https://arxiv.org/abs/2407.06788
- DataLoader loads data iteratively via row_groups, the RAM usage is now much lower, fixes #37 
- re-enable binary classifier training, set max_cands=32 for binary classification #57 via the command-line configuration